### PR TITLE
SniffFactory won't return array with null item when Sniff is excluded.

### DIFF
--- a/src/Sniff/Factory/SniffCodeToSniffsFactory.php
+++ b/src/Sniff/Factory/SniffCodeToSniffsFactory.php
@@ -45,6 +45,11 @@ final class SniffCodeToSniffsFactory implements SniffFactoryInterface
     public function create(string $sniffCode) : array
     {
         $sniffClassName = $this->router->getClassFromSniffCode($sniffCode);
-        return [$this->singleSniffFactory->create($sniffClassName)];
+        $sniff = $this->singleSniffFactory->create($sniffClassName);
+        if($sniff !== null)
+        {
+            return [$sniff];
+        }
+        return [];
     }
 }

--- a/src/Sniff/Factory/SniffCodeToSniffsFactory.php
+++ b/src/Sniff/Factory/SniffCodeToSniffsFactory.php
@@ -46,10 +46,11 @@ final class SniffCodeToSniffsFactory implements SniffFactoryInterface
     {
         $sniffClassName = $this->router->getClassFromSniffCode($sniffCode);
         $sniff = $this->singleSniffFactory->create($sniffClassName);
-        if($sniff !== null)
-        {
+        if ($sniff !== null) {
             return [$sniff];
         }
+
+
         return [];
     }
 }

--- a/tests/Sniff/SniffFactoryTest.php
+++ b/tests/Sniff/SniffFactoryTest.php
@@ -25,6 +25,9 @@ final class SniffFactoryTest extends TestCase
 
         $sniffs = $sniffSetFactory->createFromStandardsAndSniffs($standards, $extraSniffs);
         $this->assertCount($sniffCount, $sniffs);
+        foreach ($sniffs as $sniff) {
+            $this->assertNotNull($sniff, 'Null present in sniffs array');
+        }
     }
 
     public function provideDataForResolver() : array

--- a/tests/Sniff/SniffFactoryTest.php
+++ b/tests/Sniff/SniffFactoryTest.php
@@ -37,10 +37,12 @@ final class SniffFactoryTest extends TestCase
             ], [
                 ['PSR2'], ['PEAR.Commenting.ClassComment'], [], 49
             ], [
+                ['PSR2'], [], ['PSR2.Namespaces.UseDeclaration'], 48
+            ], [
                 ['PSR2'],
                 ['PEAR.Commenting.ClassComment'],
                 ['PEAR.Commenting.ClassComment', 'PSR2.Namespaces.UseDeclaration'],
-                49
+                48
             ],
         ];
     }


### PR DESCRIPTION
Return empty array instead.
Fixes null->register() call ERROR invoked later on the array items.
